### PR TITLE
Update dependencies so commons-lang3 has the current available version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This project assumes a directory structure that looks like this:
 	ThirdParty				-- A repository for third party library dependencies
 		apache
 			commons-codec-1.10
-			commons-lang3-3.3.2
+			commons-lang3-3.4
 			commons-logging-1.1.3
 		geocoder
 		google-gson-2.2.4
@@ -75,11 +75,11 @@ Be sure to either set these variables or adapt the commands below:
 	unzip commons-codec-1.10-bin.zip
     rm commons-codec-1.10-bin.zip
 
-	curl -s -O http://mirror.cc.columbia.edu/pub/software/apache//commons/lang/binaries/commons-lang3-3.3.2-bin.zip
-	unzip commons-lang3-3.3.2-bin.zip
-    rm commons-lang3-3.3.2-bin.zip
+	curl -s -O http://www.eng.lsu.edu/mirrors/apache/commons/lang/binaries/commons-lang3-3.4-bin.zip
+	unzip commons-lang3-3.4-bin.zip
+    rm commons-lang3-3.4-bin.zip
 
-	curl -s -O http://apache.mirrors.hoobly.com//commons/logging/binaries/commons-logging-1.1.3-bin.zip
+	curl -s -O http://www.eng.lsu.edu/mirrors/apache/commons/logging/binaries/commons-logging-1.1.3-bin.zip
 	unzip commons-logging-1.1.3-bin.zip
 	rm commons-logging-1.1.3-bin.zip
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-  compile 'org.apache.commons:commons-lang3:3.3.2'
+  compile 'org.apache.commons:commons-lang3:3.4'
   compile 'commons-codec:commons-codec:1.10'
   compile 'org.apache.commons:commons-io:1.3.2'
   compile 'commons-logging:commons-logging:1.1.3'

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -27,9 +27,9 @@ dist.jar=${dist.dir}/TeslaClient.jar
 dist.javadoc.dir=${dist.dir}/javadoc
 endorsed.classpath=
 excludes=
-file.reference.commons-codec-1.8.jar=../../ThirdParty/apache/commons-codec-1.8/commons-codec-1.8.jar
+file.reference.commons-codec-1.10.jar=../../ThirdParty/apache/commons-codec-1.10/commons-codec-1.10.jar
 file.reference.commons-io-2.4.jar=../../ThirdParty/apache/commons-io-2.4/commons-io-2.4.jar
-file.reference.commons-lang3-3.1.jar=../../ThirdParty/apache/commons-lang3-3.1/commons-lang3-3.1.jar
+file.reference.commons-lang3-3.4.jar=../../ThirdParty/apache/commons-lang3-3.4/commons-lang3-3.4.jar
 file.reference.commons-logging-1.1.3.jar=../../ThirdParty/apache/commons-logging-1.1.3/commons-logging-1.1.3.jar
 file.reference.commons-logging-api-1.1.3.jar=../../ThirdParty/apache/commons-logging-1.1.3/commons-logging-api-1.1.3.jar
 file.reference.geocoder-java-0.15.jar=../../ThirdParty/geocoder-java/geocoder-java-0.15.jar
@@ -38,8 +38,8 @@ file.reference.resty-0.3.2.jar=../../ThirdParty/resty/resty-0.3.2.jar
 includes=**
 jar.compress=false
 javac.classpath=\
-    ${file.reference.commons-codec-1.8.jar}:\
-    ${file.reference.commons-lang3-3.1.jar}:\
+    ${file.reference.commons-codec-1.10.jar}:\
+    ${file.reference.commons-lang3-3.4.jar}:\
     ${file.reference.commons-logging-1.1.3.jar}:\
     ${file.reference.commons-logging-api-1.1.3.jar}:\
     ${file.reference.geocoder-java-0.15.jar}:\


### PR DESCRIPTION
Update build system to match the versions in the docs.
Use a single Apache mirror for commons.