### PR TITLE
Add support for "move" state of "sun_roof_control"

### DIFF
--- a/src/org/noroomattheinn/tesla/Vehicle.java
+++ b/src/org/noroomattheinn/tesla/Vehicle.java
@@ -307,6 +307,13 @@ public class Vehicle {
         return new Result(tesla.invokeCommand(Doors_Sunroof, payload));
     }
     
+    public Result setPanoPercent(int percent){
+	 if (percent < 0 || percent > 100)
+            return new Result(false, "value out of range");
+        String payload = String.format("{'state' : 'move', 'percent' : '%d'}", percent);
+        return new Result(tesla.invokeCommand(Doors_Sunroof, payload));
+    }
+    
     public Result stopPano() {
         return new Result(tesla.invokeCommand(Doors_Sunroof, "{'state' : 'stop'}"));
     }

--- a/src/org/noroomattheinn/tesla/test/DoorHandler.java
+++ b/src/org/noroomattheinn/tesla/test/DoorHandler.java
@@ -34,6 +34,7 @@ public class DoorHandler extends TeslaHandler  {
         repl.addHandler(new DoorHandler.UnlockHandler());
         repl.addHandler(new DoorHandler.PortHandler());
         repl.addHandler(new DoorHandler.PanoHandler());
+        repl.addHandler(new DoorHandler.PanoPercentHandler());
         repl.addHandler(new DoorHandler.DisplayHandler());
     }
     
@@ -75,6 +76,15 @@ public class DoorHandler extends TeslaHandler  {
             PanoCommand cmd = PanoCommand.valueOf(CLUtils.chooseOption(
                     "Pano Command", PanoCommand.values()));
             vehicle.setPano(cmd);
+            return true;
+        }
+    }
+
+    class PanoPercentHandler extends Handler {
+        PanoPercentHandler() { super("pano_percent", "Control the roof precisely", "r"); }
+        @Override public boolean execute() {
+            int percent = (int)CLUtils.getNumberInRange("Roof Percent", 0, 100);
+            vehicle.setPanoPercent(percent);
             return true;
         }
     }


### PR DESCRIPTION
[Reference](https://timdorr.docs.apiary.io/#reference/vehicle-commands/move-pano-roof/move-pano-roof)

Not currently functional, but there are other non functioning endpoints currently in this library (e.g. open frunk/trunk), so it seems appropriate to add this.